### PR TITLE
Fix the wrong version number of transformers package

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -17,5 +17,5 @@ ray==2.6.1
 Requests==2.31.0
 shortuuid==1.0.11
 tqdm==4.64.1
-transformers==4.29.0
+transformers==4.31.0
 uvicorn==0.23.2


### PR DESCRIPTION
In transformers v4.29.0, there is no 'load_in_4bit' parameter in '[from_pretrained](https://huggingface.co/docs/transformers/v4.29.0/en/main_classes/model#transformers.PreTrainedModel.from_pretrained)' method of PreTrainedModel class. So when using 4bit data type for LISA inference, the following [code](https://github.com/dvlab-research/LISA/blob/main/model/LISA.py#L110-L124) will raise an error:

```python
elif precision == "fp16":
    if load_in_4bit:
        self.lm = LlavaLlamaForCausalLM.from_pretrained(
            llm_version,
            load_in_4bit=True,
            cache_dir=None,
            low_cpu_mem_usage=True,
            device_map="auto",
            quantization_config=BitsAndBytesConfig(
                load_in_4bit=True,
                bnb_4bit_compute_dtype=torch.float16,
                bnb_4bit_use_double_quant=True,
                bnb_4bit_quant_type="nf4",
            ),
        )
```

Updating the version of transformers to 4.31.0 can fix this bug.