### PR TITLE
Fix a bug related to displaying ce_loss

### DIFF
--- a/model/LISA.py
+++ b/model/LISA.py
@@ -306,7 +306,6 @@ class LISAForCausalLM(LlavaLlamaForCausalLM):
 
         ce_loss = model_output.loss
         ce_loss = ce_loss * self.ce_loss_weight
-        loss = ce_loss
         mask_bce_loss = 0
         mask_dice_loss = 0
         num_masks = 0
@@ -333,7 +332,7 @@ class LISAForCausalLM(LlavaLlamaForCausalLM):
         mask_dice_loss = self.dice_loss_weight * mask_dice_loss / (num_masks + 1e-8)
         mask_loss = mask_bce_loss + mask_dice_loss
 
-        loss += mask_loss
+        loss = ce_loss + mask_loss
 
         return {
             "loss": loss,


### PR DESCRIPTION
When displaying progress, the CeLoss is same as total Loss
```
Epoch: [0][  1/500]     Time 90.076 (90.076)    Loss 11.9375 (11.7625)  CeLoss 11.9375 (11.7625)        MaskLoss 1.4143 (1.2581)        MaskBCELoss 0.9156 (0.7597)     MaskDICELoss 0.4988 (0.4983)                                              
Epoch: [0][  2/500]     Time 94.826 (94.826)    Loss 10.8125 (10.9437)  CeLoss 10.8125 (10.9437)        MaskLoss 2.0747 (2.0344)        MaskBCELoss 1.5814 (1.5516)     MaskDICELoss 0.4933 (0.4828)
```